### PR TITLE
Allow mentions and topics to be overriden in the Trix editor

### DIFF
--- a/app/views/themes/base/fields/_trix_editor.html.erb
+++ b/app/views/themes/base/fields/_trix_editor.html.erb
@@ -7,12 +7,12 @@ options ||= {}
 options[:class] = "formatted_content trix-content #{options[:class]}"
 options[:placeholder] ||= labels.placeholder if labels.placeholder
 options[:data] ||= {}
-options[:data][:mentions] = ([current_team].map { |team|
+options[:data][:mentions] ||= ([current_team].map { |team|
   {key: team.name, value: team.id, protocol: 'bullettrain', model: 'teams', id: team.id, label: team.name, photo: photo_for(team)}
 } + current_team.memberships.current_and_invited.map { |membership|
   {key: membership.name, value: membership.id, protocol: 'bullettrain', model: 'memberships', id: membership.id, label: membership.name, photo: membership_profile_photo_url(membership)}
 }).to_json
-options[:data][:topics] = []
+options[:data][:topics] ||= []
 # current_team.scaffolding_things.map { |scaffolding_thing|
 #   {key: scaffolding_thing.name, value: scaffolding_thing.id, protocol: 'bullettrain', model: 'scaffolding/things', id: scaffolding_thing.id, label: scaffolding_thing.name, photo: photo_for(scaffolding_thing)}
 # }.to_json


### PR DESCRIPTION
This is to support external participants in conversations, who. may not have access to memberships.