### PR TITLE
Remove missing template reliance

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -25,10 +25,9 @@ module ThemeHelper
     if requested_partial = BulletTrain::Themes.possible_theme_render_path(options)
       original_options = options
 
-      # TODO We're hard-coding this for now, but this should probably come from the `Current` model.
-      current_theme_object.directory_order.each do |theme_path|
-        # Update our options from something like `shared/box` to `themes/light/box`.
-        options = "themes/#{theme_path}/#{requested_partial}"
+      paths = current_theme_object.partial_paths_for(requested_partial)
+      paths.each do |theme_path|
+        options = theme_path
 
         # Try rendering the partial again with the updated options.
         body = super

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -1,13 +1,4 @@
 module ThemeHelper
-  # TODO Do we want this to be configurable by downstream applications?
-  INVOCATION_PATTERNS = [
-    # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
-    /^account\/shared\//,
-
-    # ✅ This is the correct path to generically reference theme component partials with.
-    /^shared\//,
-  ]
-
   def current_theme_object
     @current_theme_object ||= "BulletTrain::Themes::#{current_theme.to_s.classify}::Theme".constantize.new
   end
@@ -32,12 +23,9 @@ module ThemeHelper
     super
   rescue ActionView::MissingTemplate
     # Does the requested partial path match one of the invocation regexes?
-    if (invocation_pattern = INVOCATION_PATTERNS.detect { |regex| options.match?(regex) })
+    if requested_partial = BulletTrain::Themes.possible_theme_render_path(options)
       # Keep track of the original options.
       original_options = options
-
-      # Trim out the base part of the requested partial.
-      requested_partial = options.gsub(invocation_pattern, "")
 
       # TODO We're hard-coding this for now, but this should probably come from the `Current` model.
       current_theme_object.directory_order.each do |theme_path|

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -19,12 +19,12 @@ module ThemeHelper
     super
   rescue ActionView::MissingTemplate
     body = current_theme_object.find_potential_partial_path_for(options) do |resolved_theme_path|
-      super(resolved_theme_path, locals, &block)
+      if @lookup_context.find_all(resolved_theme_path, [], true, locals.keys).any?
+        super(resolved_theme_path, locals, &block)
+      end
     # If calling `render` with the updated options is still resulting in a missing template, we need to
     # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
     # partial there, e.g. going from `light` to `tailwind` to `base`.
-    rescue ActionView::MissingTemplate
-      next
     end
 
     # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -22,12 +22,12 @@ module ThemeHelper
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
   rescue ActionView::MissingTemplate
-    if requested_partial = BulletTrain::Themes.possible_theme_render_path(options)
+    if theme_path = BulletTrain::Themes.theme_invocation_path_for(options)
       original_options = options
 
-      paths = current_theme_object.partial_paths_for(requested_partial)
-      paths.each do |theme_path|
-        options = theme_path
+      paths = current_theme_object.partial_paths_for(theme_path)
+      paths.each do |resolved_theme_path|
+        options = resolved_theme_path
 
         # Try rendering the partial again with the updated options.
         body = super

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -30,7 +30,7 @@ module ThemeHelper
     # However, if one of those two situations isn't true, then this call here will throw an exception and we can
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
-  rescue ActionView::MissingTemplate => exception
+  rescue ActionView::MissingTemplate
     # Does the requested partial path match one of the invocation regexes?
     if (invocation_pattern = INVOCATION_PATTERNS.detect { |regex| options.match?(regex) })
       # Keep track of the original options.
@@ -56,12 +56,12 @@ module ThemeHelper
       # If calling `render` with the updated options is still resulting in a missing template, we need to
       # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
       # partial there, e.g. going from `light` to `tailwind` to `base`.
-      rescue ActionView::MissingTemplate => _
+      rescue ActionView::MissingTemplate
         next
       end
     end
 
     # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.
-    raise exception
+    raise
   end
 end

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -18,23 +18,20 @@ module ThemeHelper
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
   rescue ActionView::MissingTemplate
-    if theme_path = BulletTrain::Themes.theme_invocation_path_for(options)
-      paths = current_theme_object.partial_paths_for(theme_path)
-      paths.each do |resolved_theme_path|
-        body = super(resolved_theme_path, locals, &block)
+    current_theme_object.partial_paths_for(options)&.each do |resolved_theme_path|
+      body = super(resolved_theme_path, locals, &block)
 
-        # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
-        BulletTrain::Themes.partial_paths[options] = resolved_theme_path
+      # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
+      BulletTrain::Themes.partial_paths[options] = resolved_theme_path
 
-        # We also need to return whatever the rendered body was.
-        return body
+      # We also need to return whatever the rendered body was.
+      return body
 
-      # If calling `render` with the updated options is still resulting in a missing template, we need to
-      # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
-      # partial there, e.g. going from `light` to `tailwind` to `base`.
-      rescue ActionView::MissingTemplate
-        next
-      end
+    # If calling `render` with the updated options is still resulting in a missing template, we need to
+    # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
+    # partial there, e.g. going from `light` to `tailwind` to `base`.
+    rescue ActionView::MissingTemplate
+      next
     end
 
     # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -18,16 +18,7 @@ module ThemeHelper
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
   rescue ActionView::MissingTemplate
-    body = current_theme_object.find_potential_partial_path_for(options) do |resolved_theme_path|
-      if @lookup_context.find_all(resolved_theme_path, [], true, locals.keys).any?
-        super(resolved_theme_path, locals, &block)
-      end
-    # If calling `render` with the updated options is still resulting in a missing template, we need to
-    # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
-    # partial there, e.g. going from `light` to `tailwind` to `base`.
-    end
-
-    # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.
-    body || raise
+    options = current_theme_object.resolve_partial_path_from(@lookup_context, options, locals) || raise
+    super
   end
 end

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -19,17 +19,12 @@ module ThemeHelper
     super
   rescue ActionView::MissingTemplate
     if theme_path = BulletTrain::Themes.theme_invocation_path_for(options)
-      original_options = options
-
       paths = current_theme_object.partial_paths_for(theme_path)
       paths.each do |resolved_theme_path|
-        options = resolved_theme_path
-
-        # Try rendering the partial again with the updated options.
-        body = super
+        body = super(resolved_theme_path, locals, &block)
 
         # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
-        BulletTrain::Themes.partial_paths[original_options] = options
+        BulletTrain::Themes.partial_paths[options] = resolved_theme_path
 
         # We also need to return whatever the rendered body was.
         return body

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -4,7 +4,7 @@ module ThemeHelper
   end
 
   def render(options = {}, locals = {}, &block)
-    options = BulletTrain::Themes.resolved_partial_path_for(options) || options
+    options = current_theme_object.resolved_partial_path_for(@lookup_context, options, locals) || options
 
     # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
     # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal
@@ -16,9 +16,6 @@ module ThemeHelper
     #
     # However, if one of those two situations isn't true, then this call here will throw an exception and we can
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
-    super
-  rescue ActionView::MissingTemplate
-    options = current_theme_object.resolve_partial_path_from(@lookup_context, options, locals) || raise
     super
   end
 end

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -22,9 +22,7 @@ module ThemeHelper
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
   rescue ActionView::MissingTemplate
-    # Does the requested partial path match one of the invocation regexes?
     if requested_partial = BulletTrain::Themes.possible_theme_render_path(options)
-      # Keep track of the original options.
       original_options = options
 
       # TODO We're hard-coding this for now, but this should probably come from the `Current` model.

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -15,15 +15,12 @@ module ThemeHelper
   def render(options = {}, locals = {}, &block)
     # The theme engine only supports `<%= render 'shared/box' ... %>` style calls to `render`.
     if options.is_a?(String)
-      # Initialize a global variable that will cache all resolutions of a given path for the entire life of the server.
-      $resolved_theme_partial_paths ||= {}
-
       # Check whether we've already resolved this partial to render from another path before.
       # If we've already resolved this partial from a different path before, then let's just skip to that.
       # TODO This should be disabled in development so new templates are taken into account without restarting the server.
-      if $resolved_theme_partial_paths[options]
+      if BulletTrain::Themes.partial_paths[options]
         # Override the value in place. This will be respected when we call `super` below.
-        options = $resolved_theme_partial_paths[options]
+        options = BulletTrain::Themes.partial_paths[options]
       end
     end
 
@@ -60,7 +57,7 @@ module ThemeHelper
             body = super
 
             # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
-            $resolved_theme_partial_paths[original_options] = options
+            BulletTrain::Themes.partial_paths[original_options] = options
 
             # We also need to return whatever the rendered body was.
             return body

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -18,7 +18,7 @@ module ThemeHelper
     # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
     super
   rescue ActionView::MissingTemplate
-    current_theme_object.partial_paths_for(options)&.each do |resolved_theme_path|
+    current_theme_object.each_potential_partial_path_for(options) do |resolved_theme_path|
       body = super(resolved_theme_path, locals, &block)
 
       # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -1,6 +1,6 @@
 module ThemeHelper
   def current_theme_object
-    @current_theme_object ||= "BulletTrain::Themes::#{current_theme.to_s.classify}::Theme".constantize.new
+    BulletTrain::Themes.themes[current_theme]
   end
 
   def render(options = {}, locals = {}, &block)

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -14,60 +14,54 @@ module ThemeHelper
 
   def render(options = {}, locals = {}, &block)
     # The theme engine only supports `<%= render 'shared/box' ... %>` style calls to `render`.
-    if options.is_a?(String)
-      # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
-      options = BulletTrain::Themes.partial_paths[options] || options
-    end
+    return super unless options.is_a?(String)
 
-    begin
-      # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
-      # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal
-      # Rails behavior.
-      #
-      # We also don't do anything special if someone renders `shared/box` and we've already previously resolved that
-      # partial to be served from `themes/light/box`. In that case, we've already replaced `shared/box` with the
-      # actual path of the partial, and Rails will do the right thing from this point.
-      #
-      # However, if one of those two situations isn't true, then this call here will throw an exception and we can
-      # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
-      super
-    rescue ActionView::MissingTemplate => exception
-      # The theme engine only supports `<%= render 'shared/box' ... %>` style calls to `render`.
-      if options.is_a?(String)
+    # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
+    options = BulletTrain::Themes.partial_paths[options] || options
 
-        # Does the requested partial path match one of the invocation regexes?
-        if (invocation_pattern = INVOCATION_PATTERNS.detect { |regex| options.match?(regex) })
-          # Keep track of the original options.
-          original_options = options
+    # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
+    # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal
+    # Rails behavior.
+    #
+    # We also don't do anything special if someone renders `shared/box` and we've already previously resolved that
+    # partial to be served from `themes/light/box`. In that case, we've already replaced `shared/box` with the
+    # actual path of the partial, and Rails will do the right thing from this point.
+    #
+    # However, if one of those two situations isn't true, then this call here will throw an exception and we can
+    # perform the appropriate magic to figure out where amongst the themes the partial should be rendering from.
+    super
+  rescue ActionView::MissingTemplate => exception
+    # Does the requested partial path match one of the invocation regexes?
+    if (invocation_pattern = INVOCATION_PATTERNS.detect { |regex| options.match?(regex) })
+      # Keep track of the original options.
+      original_options = options
 
-          # Trim out the base part of the requested partial.
-          requested_partial = options.gsub(invocation_pattern, "")
+      # Trim out the base part of the requested partial.
+      requested_partial = options.gsub(invocation_pattern, "")
 
-          # TODO We're hard-coding this for now, but this should probably come from the `Current` model.
-          current_theme_object.directory_order.each do |theme_path|
-            # Update our options from something like `shared/box` to `themes/light/box`.
-            options = "themes/#{theme_path}/#{requested_partial}"
+      # TODO We're hard-coding this for now, but this should probably come from the `Current` model.
+      current_theme_object.directory_order.each do |theme_path|
+        # Update our options from something like `shared/box` to `themes/light/box`.
+        options = "themes/#{theme_path}/#{requested_partial}"
 
-            # Try rendering the partial again with the updated options.
-            body = super
+        # Try rendering the partial again with the updated options.
+        body = super
 
-            # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
-            BulletTrain::Themes.partial_paths[original_options] = options
+        # 🏆 If we get this far, then we've found the actual path of the theme partial. We should cache it!
+        BulletTrain::Themes.partial_paths[original_options] = options
 
-            # We also need to return whatever the rendered body was.
-            return body
+        # We also need to return whatever the rendered body was.
+        return body
 
-          # If calling `render` with the updated options is still resulting in a missing template, we need to
-          # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
-          # partial there, e.g. going from `light` to `tailwind` to `base`.
-          rescue ActionView::MissingTemplate => _
-            next
-          end
-        end
+      # If calling `render` with the updated options is still resulting in a missing template, we need to
+      # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
+      # partial there, e.g. going from `light` to `tailwind` to `base`.
+      rescue ActionView::MissingTemplate => _
+        next
       end
-
-      # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.
-      raise exception
     end
+
+    # If we weren't able to find the partial in some theme-based place, then just let the original error bubble up.
+    raise exception
   end
 end

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -19,9 +19,7 @@ module ThemeHelper
     super
   rescue ActionView::MissingTemplate
     body = current_theme_object.find_potential_partial_path_for(options) do |resolved_theme_path|
-      super(resolved_theme_path, locals, &block).tap do
-        BulletTrain::Themes.partial_paths[options] = resolved_theme_path
-      end
+      super(resolved_theme_path, locals, &block)
     # If calling `render` with the updated options is still resulting in a missing template, we need to
     # keep iterating over `directory_order` to work our way up the theme stack and see if we can find the
     # partial there, e.g. going from `light` to `tailwind` to `base`.

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -4,11 +4,7 @@ module ThemeHelper
   end
 
   def render(options = {}, locals = {}, &block)
-    # The theme engine only supports `<%= render 'shared/box' ... %>` style calls to `render`.
-    return super unless options.is_a?(String)
-
-    # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
-    options = BulletTrain::Themes.partial_paths[options] || options
+    options = BulletTrain::Themes.resolved_partial_path_for(options) || options
 
     # This is where we try to just lean on Rails default behavior. If someone renders `shared/box` and also has a
     # `app/views/shared/_box.html.erb`, then no error will be thrown and we will have never interfered in the normal

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -15,13 +15,8 @@ module ThemeHelper
   def render(options = {}, locals = {}, &block)
     # The theme engine only supports `<%= render 'shared/box' ... %>` style calls to `render`.
     if options.is_a?(String)
-      # Check whether we've already resolved this partial to render from another path before.
-      # If we've already resolved this partial from a different path before, then let's just skip to that.
-      # TODO This should be disabled in development so new templates are taken into account without restarting the server.
-      if BulletTrain::Themes.partial_paths[options]
-        # Override the value in place. This will be respected when we call `super` below.
-        options = BulletTrain::Themes.partial_paths[options]
-      end
+      # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
+      options = BulletTrain::Themes.partial_paths[options] || options
     end
 
     begin

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -18,6 +18,11 @@ module BulletTrain
       /^shared\//,
     ]
 
+    def self.resolved_partial_path_for(path)
+      # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
+      partial_paths[path]
+    end
+
     def self.theme_invocation_path_for(path)
       # Themes only support `<%= render 'shared/box' ... %>` style calls to `render`, so check `path` is a string first.
       if path.is_a?(String) && (pattern = INVOCATION_PATTERNS.find { _1.match? path })

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -18,7 +18,7 @@ module BulletTrain
       /^shared\//,
     ]
 
-    def self.possible_theme_render_path(partial_path)
+    def self.theme_invocation_path_for(path)
       if pattern = INVOCATION_PATTERNS.find { _1.match? partial_path }
         partial_path.remove(pattern)
       end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -36,10 +36,10 @@ module BulletTrain
           ["base"]
         end
 
-        def each_potential_partial_path_for(path, &block)
+        def find_potential_partial_path_for(path, &block)
           # TODO directory_order should probably come from the `Current` model.
           if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
-            directory_order.map { "themes/#{_1}/#{theme_path}" }.each(&block)
+            directory_order.map { "themes/#{_1}/#{theme_path}" }.find(&block)
           end
         end
       end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -38,7 +38,9 @@ module BulletTrain
 
         def partial_paths_for(path)
           # TODO directory_order should probably come from the `Current` model.
-          directory_order.map { "themes/#{_1}/#{path}" }
+          if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
+            directory_order.map { "themes/#{_1}/#{theme_path}" }
+          end
         end
       end
     end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -29,6 +29,11 @@ module BulletTrain
         def directory_order
           ["base"]
         end
+
+        def partial_paths_for(path)
+          # TODO directory_order should probably come from the `Current` model.
+          directory_order.map { "themes/#{_1}/#{path}" }
+        end
       end
     end
   end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -36,10 +36,10 @@ module BulletTrain
           ["base"]
         end
 
-        def partial_paths_for(path)
+        def each_potential_partial_path_for(path, &block)
           # TODO directory_order should probably come from the `Current` model.
           if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
-            directory_order.map { "themes/#{_1}/#{theme_path}" }
+            directory_order.map { "themes/#{_1}/#{theme_path}" }.each(&block)
           end
         end
       end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -9,6 +9,21 @@ module BulletTrain
 
     mattr_reader :partial_paths, default: {}
 
+    # TODO Do we want this to be configurable by downstream applications?
+    INVOCATION_PATTERNS = [
+      # ❌ This path is included for legacy purposes, but you shouldn't reference partials like this in new code.
+      /^account\/shared\//,
+
+      # ✅ This is the correct path to generically reference theme component partials with.
+      /^shared\//,
+    ]
+
+    def self.possible_theme_render_path(partial_path)
+      if pattern = INVOCATION_PATTERNS.find { _1.match? partial_path }
+        partial_path.remove(pattern)
+      end
+    end
+
     module Base
       class Theme
         def directory_order

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -34,9 +34,9 @@ module BulletTrain
         def resolved_partial_path_for(lookup_context, path, locals)
           # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
           BulletTrain::Themes.partial_paths.fetch(path) do
-            if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
+            if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
               # TODO directory_order should probably come from the `Current` model.
-              if partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first
+              if (partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
                 BulletTrain::Themes.partial_paths[path] = partial.virtual_path.gsub("/_", "/")
               end
             end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -7,6 +7,8 @@ module BulletTrain
     mattr_accessor :themes, default: {}
     mattr_accessor :logo_height, default: 54
 
+    mattr_reader :partial_paths, default: {}
+
     module Base
       class Theme
         def directory_order

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -39,7 +39,11 @@ module BulletTrain
         def find_potential_partial_path_for(path, &block)
           # TODO directory_order should probably come from the `Current` model.
           if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
-            directory_order.map { "themes/#{_1}/#{theme_path}" }.find(&block)
+            directory_order.map { "themes/#{_1}/#{theme_path}" }.find do |resolved_theme_path|
+              yield(resolved_theme_path)&.tap do
+                BulletTrain::Themes.partial_paths[path] = resolved_theme_path
+              end
+            end
           end
         end
       end

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -19,8 +19,9 @@ module BulletTrain
     ]
 
     def self.theme_invocation_path_for(path)
-      if pattern = INVOCATION_PATTERNS.find { _1.match? partial_path }
-        partial_path.remove(pattern)
+      # Themes only support `<%= render 'shared/box' ... %>` style calls to `render`, so check `path` is a string first.
+      if path.is_a?(String) && (pattern = INVOCATION_PATTERNS.find { _1.match? path })
+        path.remove(pattern)
       end
     end
 

--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -36,13 +36,11 @@ module BulletTrain
           ["base"]
         end
 
-        def find_potential_partial_path_for(path, &block)
-          # TODO directory_order should probably come from the `Current` model.
+        def resolve_partial_path_from(lookup_context, path, locals)
           if theme_path = BulletTrain::Themes.theme_invocation_path_for(path)
-            directory_order.map { "themes/#{_1}/#{theme_path}" }.find do |resolved_theme_path|
-              yield(resolved_theme_path)&.tap do
-                BulletTrain::Themes.partial_paths[path] = resolved_theme_path
-              end
+            # TODO directory_order should probably come from the `Current` model.
+            if partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first
+              BulletTrain::Themes.partial_paths[path] = partial.virtual_path.gsub("/_", "/")
             end
           end
         end


### PR DESCRIPTION
Currently we're resolving theme partials by catching consecutive `ActionView::MissingTemplate` errors.

This can be costly if we're using the light theme and resolve something in base, then we'll lookup and raise for each of `themes/light/x`, `themes/tailwind_css/x`, and `themes/base/x`.

This replaces our `MissingTemplate` reliance with a single lookup through the view's `@lookup_context`.

### This is ready to merge, but I'm also working on an alternate version of this

While working on this, I realized we could have each theme create a hash of all the resolved template paths up front. E.g. the light theme could have:

```ruby
{ "box" => "themes/light/box", "attributes/something" => "themes/base/attributes/something" }
```

which is built with something like this:

```ruby
def resolve_partial_paths
  superclass.try(:partials_paths).to_h.merge(partial_paths)
end

def partial_paths
  root.glob("app/views/themes/#{theme_name}/{*,**/*}").map { normalize_partial_path _1 }
end
```