### PR TITLE
Allow custom data attributes for super select

### DIFF
--- a/app/views/themes/base/fields/_super_select.html.erb
+++ b/app/views/themes/base/fields/_super_select.html.erb
@@ -26,7 +26,8 @@ wrapper_options = { data: { controller: stimulus_controller }}
 wrapper_options[:data]["#{stimulus_controller}-enable-search-value"] = true if other_options[:search]
 wrapper_options[:data]["#{stimulus_controller}-accepts-new-value"] = true if other_options[:accepts_new]
 wrapper_options[:data]["#{stimulus_controller}-search-url-value"] = choices_url if choices_url.present?
-html_options[:data] = { "#{stimulus_controller}-target": 'select' }
+html_options[:data] ||= {}
+html_options[:data].merge!("#{stimulus_controller}-target": 'select')
 
 %>
 


### PR DESCRIPTION
I wanted to be able to assign a custom data attribute to a super select but I couldn't do it with the current implementation of this partial.

This change allows me to set additional data attributes like this

```
      <%= render 'shared/fields/super_select',
        method: :thing_id,
        choices: Things.all.map {|c| [c.name, c.id]},
        html_options: { data: { things_target: "thingSelect" } }
      %>
```