### PR TITLE
Hide password field when using text partials

### DIFF
--- a/app/views/themes/base/attributes/_text.html.erb
+++ b/app/views/themes/base/attributes/_text.html.erb
@@ -1,9 +1,10 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% options ||= {} %>
 
 <% if object.send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= object.send(attribute) %>
+    <%= options[:password] ? "●" * object.send(attribute).length : object.send(attribute) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/49

I'm not sure if we actually need this, but I thought it would be good to hide passwords on the index and show actions after Super Scaffolding a `password_field`:

![Screenshot from 2022-08-11 17-06-13](https://user-images.githubusercontent.com/10546292/184090652-99b9b417-c5e4-4211-95fe-d3f504d0d943.png)

The only caveat is that when `password_field` is the first attribute being Super Scaffolded, it will show up in the title (for example, it will be displayed where "Foo" is displayed at the very top in the above picture).
