### PR TITLE
Monkey patch to ensure custom devise views are used

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -1,3 +1,39 @@
+# Our custom devise views are housed in `bullet_train-base`, but they're overwritten
+# by devise's standard views if the devise gem is declared after `bullet_train`.
+# To ensure we use our custom views, we temporarily unregister the original devise
+# views path from the FileSystemResolver, add our custom path, and find the views that way.
+module ActionView
+  class LookupContext
+    module ViewPaths
+      def find(name, prefixes = [], partial = false, keys = [], options = {})
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for(options)
+
+        devise_view = false
+        prefixes.each do |prefix|
+          if prefix.match?(/devise/)
+            devise_view = true
+            break
+          end
+        end
+
+        resolver = if name == "devise" || devise_view
+          original_devise_view_path = BulletTrain::Themes::Light.original_devise_path
+          bullet_train_resolver = @view_paths.paths.reject do |resolver|
+            resolver.path.match?(original_devise_view_path)
+          end
+          PathSet.new(bullet_train_resolver)
+        else
+          @view_paths
+        end
+
+        resolver.find(name, prefixes, partial, details, details_key, keys)
+      end
+      alias :find_template :find
+    end
+  end
+end
+
 module ThemeHelper
   # TODO Do we want this to be configurable by downstream applications?
   INVOCATION_PATTERNS = [

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -29,7 +29,7 @@ module ActionView
 
         resolver.find(name, prefixes, partial, details, details_key, keys)
       end
-      alias :find_template :find
+      alias_method :find_template, :find
     end
   end
 end


### PR DESCRIPTION
This addresses the issue in the starter repo which ignored our custom devise views in `bullet_train-base` whenever we added `gem devise` below the Bullet Train gems in the Gemfile.

Joint PRs
- https://github.com/bullet-train-co/bullet_train-themes-light/pull/46
- https://github.com/bullet-train-co/bullet_train/pull/358

Main things to note here:
1. `@view_paths.path` had a list of the paths we call our views from, which included both `bullet_train` and `devise`.
2. I grabbed the original devise path with `bundle show devise` so we could ignore it in `resolver`, a copy of `@view_paths` so we don't delete devise from the original `@view_paths` altogether. I ended up putting this in an initializer in the starter repo so we can cut down on unnecessary overhead by calling `bundle show` each time.

What's the best way to implement this monkey patch? I've kind of just placed it right here in the theme helper, but if there's a better place I'd be glad to move it.