### PR TITLE
Revert to creating a current theme object from instance

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -36,7 +36,7 @@ end
 
 module ThemeHelper
   def current_theme_object
-    BulletTrain::Themes.themes[current_theme]
+    @current_theme_object ||= "BulletTrain::Themes::#{current_theme.to_s.classify}::Theme".constantize.new
   end
 
   def render(options = {}, locals = {}, &block)


### PR DESCRIPTION
#12 cut down on a lot of the `render` code which is awesome! The only thing was that ejecting a theme was breaking, so I reverted to using the previous code for this one line.

What do you think @kaspth? Is there a better way to handle this?
