### PR TITLE
Use `directory_order` from the `Current` class when resolving partials

### DIFF
--- a/lib/bullet_train/themes.rb
+++ b/lib/bullet_train/themes.rb
@@ -35,8 +35,7 @@ module BulletTrain
           # TODO This caching should be disabled in development so new templates are taken into account without restarting the server.
           BulletTrain::Themes.partial_paths.fetch(path) do
             if (theme_path = BulletTrain::Themes.theme_invocation_path_for(path))
-              # TODO directory_order should probably come from the `Current` model.
-              if (partial = lookup_context.find_all(theme_path, directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
+              if (partial = lookup_context.find_all(theme_path, Current.directory_order.map { "themes/#{_1}" }, true, locals.keys).first)
                 BulletTrain::Themes.partial_paths[path] = partial.virtual_path.gsub("/_", "/")
               end
             end


### PR DESCRIPTION
Addresses the TODO in `lib/bullet_train/themes.rb`

This is the main PR.
Joint PRs are here:
- https://github.com/bullet-train-co/bullet_train/pull/387
- https://github.com/bullet-train-co/bullet_train-base/pull/103

## Details
I was kind of confused as to how to handle this one at first, but I'm glad I sifted through it. Now I understand a bit more about the `Theme` class hierarchy we have going on here.

Although the logic itself hasn't been changed (we're still retrieving the same array regardless if we use the default light theme or an ejected theme), we can set things up this way if we want to call `Current.directory_order` instead.

Tagging @kaspth because I believe you wrote the TODO; if I'm misunderstanding the concept just let me know and I'd be glad to look over what I wrote!