### PR TITLE
Remove any blank elements in option partial object arrays

### DIFF
--- a/app/views/themes/base/attributes/_options.html.erb
+++ b/app/views/themes/base/attributes/_options.html.erb
@@ -4,7 +4,8 @@
 
 <% if object.send(attribute).any? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
-    <%= object.send(attribute).map do |value| %>
+    <%# TODO: Multiple option partials return arrays with blank characters in them. Is this expected? %>
+    <%= object.send(attribute).reject(&:blank?).map do |value| %>
       <% t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{value}") %>
     <% end.map(&:strip).to_sentence %>
   <% end %>


### PR DESCRIPTION
The Super Scaffolding system test for partials was failing, so I looked into it and found the following.

Multiple buttons weren't giving us an issue, but multiple options were the culprit.
```
[1] pry(#<#<Class:0x00007f9d74f654a0>>)> object.send(attribute).map do |value|
[1] pry(#<#<Class:0x00007f9d74f654a0>>)*   t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{value}")
[1] pry(#<#<Class:0x00007f9d74f654a0>>)* end  
=> [{:one=>"One", :two=>"Two", :three=>"Three"},
 "One",
 {:one=>"One", :two=>"Two", :three=>"Three"},
 {:one=>"One", :two=>"Two", :three=>"Three"},
 "Three"]
[2] pry(#<#<Class:0x00007f9d74f654a0>>)> 
```

The object itself returned the following:
```
[3] pry(#<#<Class:0x00007f9d74f654a0>>)> object.send(attribute)
=> ["", "one", "", "", "three"]
```

I used `reject(&:blank?)` to resolve the issue, but I also added a TODO because I hope it's not just a band-aid to cover up for something else that should be addressed:
```
[2] pry(#<#<Class:0x00007efd90022c88>>)> object.send(attribute).reject(&:blank?).map do |value|
[2] pry(#<#<Class:0x00007efd90022c88>>)*   t("#{object.class.name.underscore.pluralize}.fields.#{attribute}.options.#{value}")
[2] pry(#<#<Class:0x00007efd90022c88>>)* end.map(&:strip).to_sentence  
=> "One and Three"
```

With this fix we now get the following error instead, but I addressed this in https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/49 so I won't deal with it in this PR:
```
Error:
SuperScaffoldingSystemTest#test_super_scaffolded_partials_function_properly:
RuntimeError: Neutered Exception ActionView::Template::Error: Missing partial shared/attributes/_string with {:locale=>[:en], :formats=>[:html, :turbo_stream], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}.
```