### PR TITLE
Add a default message for dates and date times in views

### DIFF
--- a/app/views/themes/base/attributes/_date.html.erb
+++ b/app/views/themes/base/attributes/_date.html.erb
@@ -1,9 +1,12 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
 <% if object.send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= display_date(object.send(attribute), local_assigns[:date_format]) %>
   <% end %>
+<% else %>
+  <%= default_message %>
 <% end %>

--- a/app/views/themes/base/attributes/_date_and_time.html.erb
+++ b/app/views/themes/base/attributes/_date_and_time.html.erb
@@ -1,9 +1,12 @@
 <% object ||= current_attributes_object %>
 <% strategy ||= current_attributes_strategy || :none %>
 <% url ||= nil %>
+<% default_message = local_assigns[:default_message] || t('global.formats.timestamp_unavailable') %>
 
 <% if object.send(attribute).present? %>
   <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
     <%= display_date_and_time(object.send(attribute), local_assigns[:date_format], local_assigns[:time_format]) %>
   <% end %>
+<% else %>
+  <%= default_message %>
 <% end %>


### PR DESCRIPTION
Joint PRs
- https://github.com/bullet-train-co/bullet_train-api/pull/29
- https://github.com/bullet-train-co/bullet_train-base/pull/116

This allows us to display a message if the `Date` or `DateTime` is `nil`, instead of just showing blank space.