### PR TITLE
super-select: catch keydown and open if not multiple

### DIFF
--- a/app/views/themes/base/fields/_super_select.html.erb
+++ b/app/views/themes/base/fields/_super_select.html.erb
@@ -26,6 +26,12 @@ wrapper_options = { data: { controller: stimulus_controller }}
 wrapper_options[:data]["#{stimulus_controller}-enable-search-value"] = true if other_options[:search]
 wrapper_options[:data]["#{stimulus_controller}-accepts-new-value"] = true if other_options[:accepts_new]
 wrapper_options[:data]["#{stimulus_controller}-search-url-value"] = choices_url if choices_url.present?
+
+unless options[:multiple]
+  wrapper_options[:data]["action"] ||= ""
+  wrapper_options[:data]["action"] += " keydown->#{stimulus_controller}#injectKeystrokeIntoTextField $select2:open->#{stimulus_controller}#focusOnTextField"
+end
+
 html_options[:data] ||= {}
 html_options[:data].merge!("#{stimulus_controller}-target": 'select')
 


### PR DESCRIPTION
For `super_select` fields that don't allow multiple selections, this introduces these improvements:

1. When clicking on the field, the focus goes onto the search text input field
2. When closed, but the field has focus, if you start typing, the field opens and lets you type directly into the search text input field.

Closes https://github.com/bullet-train-co/bullet_train-fields/issues/35

Requires https://github.com/bullet-train-co/bullet_train-fields/pull/33 (a commit from that PR's branch is included in this branch)

Co-dependent PRs:
* https://github.com/bullet-train-co/bullet_train-fields/pull/36
* https://github.com/bullet-train-co/bullet_train/pull/435