### PR TITLE
Install themes dynamically by passing an argument

### DIFF
--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -2,6 +2,10 @@ module BulletTrain
   module Themes
     module Application
       def self.install_theme(theme_name)
+        unless theme_name == "light" || Dir.exists?("app/views/themes/#{theme_name}")
+          raise "We could not find '#{theme_name}'. Please eject Bullet Train's standard views to your main application first by using `rake bullet_train:themes:light:eject[custom_theme_name_here]`".red
+        end
+
         # Grabs the current theme from
         # def current_theme
         #   :theme_name

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -1,0 +1,37 @@
+module BulletTrain
+  module Themes
+    module Application
+      def self.install_theme(theme_name)
+        # Grabs the current theme from
+        # def current_theme
+        #   :theme_name
+        # end
+        current_theme_regexp = /(^    :)(.*)/
+        current_theme = nil
+
+        new_lines = []
+        [
+          "./app/helpers/application_helper.rb",
+          "./Procfile.dev",
+          "./package.json"
+        ].each do |file|
+          File.open(file, "r") do |f|
+            new_lines = f.readlines
+            new_lines = new_lines.map do |line|
+              # Make sure we get the current theme before trying to replace it in any of the files.
+              # We grab it from the first file in the array above.
+              current_theme = line.scan(current_theme_regexp).flatten.last if line.match?(current_theme_regexp)
+
+              line.gsub!(/#{current_theme}/, theme_name) unless current_theme.nil?
+              line
+            end
+          end
+
+          File.open(file, "w") do |f|
+            f.puts new_lines.join
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/application.rb
+++ b/lib/tasks/application.rb
@@ -2,7 +2,7 @@ module BulletTrain
   module Themes
     module Application
       def self.install_theme(theme_name)
-        unless theme_name == "light" || Dir.exists?("app/views/themes/#{theme_name}")
+        unless theme_name == "light" || Dir.exist?("app/views/themes/#{theme_name}")
           raise "We could not find '#{theme_name}'. Please eject Bullet Train's standard views to your main application first by using `rake bullet_train:themes:light:eject[custom_theme_name_here]`".red
         end
 

--- a/lib/tasks/bullet_train/themes_tasks.rake
+++ b/lib/tasks/bullet_train/themes_tasks.rake
@@ -1,4 +1,9 @@
-# desc "Explaining what the task does"
-# task :bullet_train_themes do
-#   # Task goes here
-# end
+require "tasks/application"
+
+namespace :bullet_train do
+  namespace :themes do
+    task :install, [:theme_name] => :environment do |task, args|
+      BulletTrain::Themes::Application.install_theme(args[:theme_name])
+    end
+  end
+end

--- a/lib/tasks/bullet_train/themes_tasks.rake
+++ b/lib/tasks/bullet_train/themes_tasks.rake
@@ -1,4 +1,4 @@
-require "tasks/application"
+require_relative "../application"
 
 namespace :bullet_train do
   namespace :themes do


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-themes-light/issues/55

Joint PR
- https://github.com/bullet-train-co/bullet_train-themes-light/pull/56

## Details
This is pretty much the same code from `bullet_train-themes-light`, I just thought it would be more appropriate to have it here since we should be able to install any theme, not just the `light` theme. I removed the code in `bullet_train-themes-light`, but I also had to add the `Light` namespace to the `Application` module because `BulletTrain::Themes::Application` was overlapping with the module here.